### PR TITLE
fix error can't add list and range

### DIFF
--- a/sldp/chunkstats.py
+++ b/sldp/chunkstats.py
@@ -55,7 +55,7 @@ def collapse_to_chunks(ldblocks, numerators, denominators, numblocks):
 
 # compute estimate of effect size
 def get_est(num, denom, k, num_background):
-    ind = range(num_background) + [num_background+k]
+    ind = list(range(num_background)) + [num_background+k]
     num = num[ind]
     denom = denom[ind][:,ind]
     try:


### PR DESCRIPTION
Current pip install version gives run-time error:

```
 File "/home/pauline/.local/lib/python3.8/site-packages/sldp/chunkstats.py", line 59, in get_est
    ind = range(num_background) + [num_background+k]
TypeError: unsupported operand type(s) for +: 'range' and 'list'
```
So I changed line 59 of chunkstats.py

Old:
`ind = range(num_background) + [num_background+k]`
New:
`ind = list(range(num_background)) + [num_background+k]`

**Validation:** After fix, sldp could run and results matched [mini-example](https://github.com/yakirr/sldp/wiki/Minimal-example#run-sldp)
